### PR TITLE
Refactor auth

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,27 +1,10 @@
 import bcrypt from "bcrypt";
-import jwt from "jsonwebtoken";
 import { APIGatewayProxyEvent } from "aws-lambda";
+
 import UserModel from "./schema/user/model";
-
-export interface DecodedUserToken {
-  email: string;
-}
-
-export interface User {
-  email: string;
-  password: string;
-}
-
-const isDecodedUserToken = (input: any): input is DecodedUserToken => (input as DecodedUserToken).email !== undefined;
-
-const decodeToken = (token: string): DecodedUserToken | null => {
-  try {
-    const decoded = jwt.verify(token, process.env.SECRET_KEY);
-    return isDecodedUserToken(decoded) ? decoded : null;
-  } catch (e) {
-    return null;
-  }
-};
+import type { User } from "./schema/user/backingType.d";
+import { isUser } from "./schema/user/utils";
+import { DecodedUserToken, UserToken } from "./auth/UserToken";
 
 const getTokenFromAuthHeader = (event: APIGatewayProxyEvent) => {
   if (event.headers && event.headers.Authorization) {
@@ -30,23 +13,24 @@ const getTokenFromAuthHeader = (event: APIGatewayProxyEvent) => {
   return null;
 };
 
-const verifyPassword = (user: User, password: string) => bcrypt.compareSync(password, user.password);
+const verifyPassword = (reference: string, given: string) => bcrypt.compareSync(given, reference);
 
-const verifyUserExists = async (user: DecodedUserToken) => {
-  const existingUser = await UserModel.get(user.email);
+const verifyUserExists = async (email: string) => {
+  const existingUser = await UserModel.get(email);
   return !!existingUser;
 };
 
-const convertDBUserToDecodedToken = (user: User): DecodedUserToken => ({
-  email: user.email,
-});
+// const getDecodedUserTokenFromUser = (user: User): DecodedUserToken => ({
+// email: user.email,
+// });
 
 export const getUserFromRequest = async (event: APIGatewayProxyEvent) => {
   const token = getTokenFromAuthHeader(event);
   if (token) {
-    const decodedUser = decodeToken(token);
+    const decodedUser = new DecodedUserToken(token);
+
     if (decodedUser) {
-      if (verifyUserExists(decodedUser)) {
+      if (verifyUserExists(decodedUser.payload.email)) {
         return decodedUser;
       }
     }
@@ -58,21 +42,26 @@ export const getUserTokenFromCredentials = async (
   email: string,
   password: string,
 ) => {
-  // find the user by email
-  const user = await UserModel.get(email);
+  const userDocument = await UserModel.get(email);
 
-  // @ts-ignore
-  if (user && isDecodedUserToken(user) && verifyPassword(user, password)) {
-    // @ts-ignore
-    const userToken = convertDBUserToDecodedToken(user);
-    const token = jwt.sign(userToken, process.env.SECRET_KEY);
-    return { token };
+  if (
+    !DecodedUserToken.isUserTokenPayload(userDocument)
+    || !isUser(userDocument)
+  ) {
+    throw Error("User Does Not Exist");
+  } else if (!verifyPassword(userDocument.password, password)) {
+    throw Error("Incorrect Password");
   }
-  return { token: "" };
+
+  const { token } = new DecodedUserToken(userDocument).encode();
+
+  return { token };
 };
 
 export const hashPassword = (password: string) => bcrypt.hashSync(password, 3);
+export const getTokenFromUser = (user: User) => new DecodedUserToken(user).encode();
 
-export const getTokenFromUser = (user: DecodedUserToken) => ({
-  token: jwt.sign({ email: user.email }, process.env.SECRET_KEY),
-});
+// export const getTokenFromUser = (user: DecodedUserToken) => ({
+// token:
+// token: jwt.sign({ email: user.email }, process.env.SECRET_KEY),
+// });

--- a/src/auth/UserToken.ts
+++ b/src/auth/UserToken.ts
@@ -1,0 +1,44 @@
+export interface UserTokenPayload {
+  email: string;
+}
+
+export class UserToken {
+  token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  decode = () => {
+    const payload = jwt.verify(this.token, process.env.SECRET_KEY);
+    // need to make sure the decodedToken fits the UserTokenPayload interface
+    if (!DecodedUserToken.isUserTokenPayload(payload)) {
+      throw new Error(
+        "Could not decode Token: Decoded payload is not a user payload",
+      );
+    }
+    return new DecodedUserToken(payload);
+  };
+}
+
+export class DecodedUserToken {
+  payload: UserTokenPayload;
+
+  constructor(payload: UserTokenPayload) {
+    this.payload = payload;
+  }
+
+  encode = () => {
+    const token = jwt.sign(this.payload, process.env.SECRET_KEY);
+    return new UserToken(token);
+  };
+
+  static isUserTokenPayload = (input: any): input is UserTokenPayload => {
+    const keys = Object.keys(input);
+    return (
+      keys.length === 1
+      && keys[0] === "email"
+      && typeof input.email === "string"
+    );
+  };
+}

--- a/src/schema/user/backingType.d.ts
+++ b/src/schema/user/backingType.d.ts
@@ -1,4 +1,8 @@
-export interface User {
+export interface UserRecord {
   email: string;
   password: string;
+}
+
+export interface User {
+  email: string;
 }

--- a/src/schema/user/query.ts
+++ b/src/schema/user/query.ts
@@ -2,7 +2,7 @@ import {
   queryField, extendType, stringArg, intArg,
 } from "@nexus/schema";
 import model from "./model";
-import { isUser } from "./utils";
+import { isUserRecord } from "./utils";
 
 export const addUserCrudToQuery = extendType({
   type: "Query",
@@ -11,8 +11,10 @@ export const addUserCrudToQuery = extendType({
       type: "User",
       args: { id: stringArg({ required: true }) },
       resolve: async (_root, { id }) => {
-        const document = await model.get({ id });
-        return isUser(document) ? document : { email: "", password: "" };
+        const userRecord = await model.get({ id });
+        return isUserRecord(userRecord)
+          ? userRecord
+          : { email: "", password: "" };
       },
     });
   },
@@ -22,8 +24,10 @@ export const me = queryField("me", {
   type: "User",
   resolve: async (_root, _args, { user }) => {
     if (user) {
-      const userDocument = await model.get({ email: user.email });
-      return isUser(userDocument) ? userDocument : { email: "", password: "" };
+      const userRecord = await model.get({ email: user.email });
+      return isUserRecord(userRecord)
+        ? userRecord
+        : { email: "", password: "" };
     }
     return { email: "", password: "" };
   },
@@ -34,9 +38,9 @@ export const users = queryField("users", {
   list: true,
   args: { last: intArg({ default: 5, nullable: false }) },
   resolve: async (_, { last }) => {
-    const userDocuments = await model.scan().limit(last).exec();
-    if (isUser(userDocuments[0])) {
-      return userDocuments;
+    const userRecords = await model.scan().limit(last).exec();
+    if (isUserRecord(userRecords[0])) {
+      return userRecords;
     }
     return { email: "", password: "" };
   },

--- a/src/schema/user/utils.ts
+++ b/src/schema/user/utils.ts
@@ -1,6 +1,20 @@
-import type { User } from "./backingType.d";
+import type { User, UserRecord } from "./backingType.d";
+import UserModel from "./model";
+
+export const isUserRecord = (input: any): input is UserRecord => {
+  const userModel = input as UserRecord;
+  return userModel.email !== undefined && userModel.password !== undefined;
+};
 
 export const isUser = (input: any): input is User => {
-  const user = input as User;
-  return user.email !== undefined && user.password !== undefined;
+  const keys = Object.keys(input);
+  return (
+    keys.length === 1 && keys[0] === "email" && typeof input.email === "string"
+  );
 };
+
+export const verifyUserRecordExists = async ({
+  email,
+}: User): Promise<Boolean> => !!UserModel.get(email);
+
+export const getUserRecordFromEmail = async (email: string) => UserModel.get(email);


### PR DESCRIPTION
This change looks a lot bigger than it is.  I basically just cleaned up the functionality for authenticating against the api.  

You can ignore the original commit, I ended up ditching the OOP solution.

- moved token logic into its own module under auth
- added some error handling
- added a new backing type to distinguish users from userRecords (the functional difference is that userRecords have a password field, whereas users do not.  I think this could be cleaned up better actually)
- added new typeguards for users and userRecords  *because I named the original typeguard poorly, I had to change its name throughout the project :( *
- added helper functions to user utils.  I think what I would like to do is wrap these utils and the dynamoose model into a UserModel class.  Maybe it can have a 'getUser' method which returns a user stripped of its password.  this would be a lot cleaner...

Sorry this is so big.  I tried to keep it very contained, but when you change stuff at the top level it sort of has a trickle-down effect.  Do notice that change doesn't affect the schema at all so its not breaking, though you might get some better error handling on the client side.